### PR TITLE
Typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,16 @@
 
 
 A simple viewer for Sanger trace file made with Qt5.
-Support AB1 and SCF 3.0 file format.
+Supports AB1 and SCF 3.0 file formats.
 
 ![Preview](https://raw.githubusercontent.com/labsquare/CutePeaks/master/cutepeaks.gif)
 
 
 # Installation
 ## Linux
-Linux binary is avaible as [appImage](http://appimage.org/).
-Download the appimage from [here](https://github.com/labsquare/CutePeaks/releases)
-Run it as follow :
+Linux binary is available as [AppImage](http://appimage.org/).
+Download the AppImage from [here](https://github.com/labsquare/CutePeaks/releases).
+Run it as follow:
 
 
     chmod +x cutepeaks-0.1.0-linux-x86_64.appimage
@@ -22,25 +22,27 @@ Run it as follow :
 
 
 ## Compilation
-### Prerequisites - Install KArchive
-### Install Qt >5.7
+### Prerequisites
+#### Install KArchive
 
-**From website** : Download Qt > 5.7 from https://www.qt.io/.
+#### Install Qt ≥ 5.7
+
+**From website**: Download Qt ≥ 5.7 from https://www.qt.io/.
 Don't forget to check QtChart module during installation.
 
-**From ubuntu** : Qt 5.7 is not yet avaible with ubuntu. But you can add PPA to your software system.
-For exemple from xenial
+**From Ubuntu**: Qt 5.7 is not yet available with Ubuntu. But you can add a PPA to your software system.
+For exemple for Xenial:
 
     sudo add-apt-repository ppa:beineri/opt-qt57-xenial
-    sudo apt-get install qt57base qt57charts-no-lgpl
+    sudo apt install qt57base qt57charts-no-lgpl
     source /opt/qt57/bin/qt57-env.sh
 
-**From fedora** : Qt 5.7 is avaible
+**From Fedora**: Qt 5.7 is available.
 
     sudo dnf install qt5-qtbase-devel qt5-qtcharts-devel
 
 ### Compile CutePeaks
-Be sure you have the correct version of Qt (>5.7) by using qmake --version. For exemple, if you have installed Qt from ppa:beineri, you will find it under /opt/qt57/bin/qmake. Then launch the compilation from CutePeaks folder as follow.
+Be sure you have the correct version of Qt (≥ 5.7) by using qmake --version. For exemple, if you have installed Qt from ppa:beineri, you will find it under /opt/qt57/bin/qmake. Then launch the compilation from CutePeaks folder as follow.
 
      /opt/qt57/bin/qmake --version
      /opt/qt57/bin/qmake
@@ -49,10 +51,10 @@ Be sure you have the correct version of Qt (>5.7) by using qmake --version. For 
 
 ## Usage
 
-Cutepeaks support following trace file:
+CutePeaks supports following trace file formats:
 
 - *.ab1
 - *.scf
 
 ## How to cite CutePeaks
-Labsquare Team, et al (2017). CutePeaks: a simple Sanger trace file. Avaible online at https://github.com/labsquare/CutePeaks doi:10.5281/zenodo.824555
+Labsquare Team (2017). CutePeaks: a simple Sanger trace file. Available online at https://github.com/labsquare/CutePeaks doi:10.5281/zenodo.824555


### PR DESCRIPTION
Note: "Et al." means "and others" and is not appropriate here because authors belong to Labsquare Team.