### PR TITLE
Fixed icon being placed in the wrong directory

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -32,7 +32,7 @@ desktop.files += ../cutepeaks.desktop
 desktop.path = /usr/share/applications/
 
 icons.files += ../cutepeaks.png
-icons.path = /usr/share/icons/hicolor/48x48/apps
+icons.path = /usr/share/icons/hicolor/64x64/apps
 
 target.path = /usr/bin/
 


### PR DESCRIPTION
This fixes an rpmlint warning I encountered while packaging this for @openSUSE science.